### PR TITLE
feat: init LangChain prompt template

### DIFF
--- a/django_gen_ai_examples/apps/chat_bot/api/urls.py
+++ b/django_gen_ai_examples/apps/chat_bot/api/urls.py
@@ -12,4 +12,5 @@ urlpatterns = [
     path('single-prompt/', views.SinglePromptAPIView.as_view(), name='single_prompt'),
     path('summarize/', views.SummarizeTextAPIView.as_view(), name='summarize_text'),
     path('sentiment/', views.SentimentAnalysisAPIView.as_view(), name='sentiment_analysis'),
+    path('lc-prompt-template/', views.LCPromptTemplateAPIView.as_view(), name="prompt_template"),
 ]

--- a/django_gen_ai_examples/apps/chat_bot/api/views.py
+++ b/django_gen_ai_examples/apps/chat_bot/api/views.py
@@ -6,11 +6,17 @@ from typing import Dict, Optional
 
 from django.template.exceptions import TemplateDoesNotExist
 from django.template.loader import render_to_string
+from langchain.prompts import ChatPromptTemplate
+
+# from langchain.chat_models import ChatGooglePalm # Deprecated.
+# from langchain_community.chat_models import ChatGooglePalm # Deprecated
+from langchain_google_genai.chat_models import ChatGoogleGenerativeAI
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from chat_bot.utils import gemini_completion_request
+from chat_bot.const import GeminiAPIConstants
+from chat_bot.utils import gemini_completion_request, get_gemini_api_key
 
 
 class PromptBasedAPIView(APIView):
@@ -104,3 +110,43 @@ class SentimentAnalysisAPIView(PromptBasedAPIView):
     "Performs sentiment analysis on the provided text using Gemini API"
 
     prompt_template_name = "sentiment_prompt.txt"
+
+
+class LCPromptTemplateAPIView(APIView):
+    "LangChain simple prompt template using the modern ChatGoogleGenerativeAI."
+
+    def post(self, request, *_, **__):
+        "Pass prompt through LangChain PromptTemplate"
+        request_message = request.data.get("message")
+        if not request_message:
+            return Response({"error": "Missing message"}, status=status.HTTP_400_BAD_REQUEST)
+
+        chat = ChatGoogleGenerativeAI(
+            temperature=0.0,
+            model=GeminiAPIConstants.MODEL,
+            google_api_key=get_gemini_api_key(),
+        )
+
+        template_string = """Translate the text \
+that is delimited by triple backticks \
+into a style that is {style}. \
+text: ```{text}```
+"""
+
+        style_instruction = """Indian Tamil \
+in a calm and respectful tone
+"""
+
+        prompt_template = ChatPromptTemplate.from_template(template_string)
+
+        formatted_prompt = prompt_template.format_messages(
+            style=style_instruction,
+            text=request_message,
+        )
+
+        api_response = chat.invoke(formatted_prompt)
+
+        response_content = api_response.content
+
+        response_data = {"message": response_content}
+        return Response(response_data, status=status.HTTP_200_OK)

--- a/django_gen_ai_examples/apps/chat_bot/const.py
+++ b/django_gen_ai_examples/apps/chat_bot/const.py
@@ -12,6 +12,7 @@ class SidebarMenuChoices:
 
     # Main categories:
     COMPLETIONS = "Completions"
+    LANG_CHAIN = "LangChain"
 
     # JSON keys for sidebar menu items (Used by FE-Vue):
     NAME_KEY = "name"
@@ -35,9 +36,13 @@ class SidebarMenuChoices:
                     {cls.NAME_KEY: 'Sentiment analysis', cls.API_URL_NAME_KEY: 'chatbot-api:sentiment_analysis'},
                 ],
             },
-            # TODO: Add more categories as needed:
-            # {cls.NAME_KEY: 'Cat 2', cls.API_URL_KEY: 'chatbot-api:cat_2'},
-            # {cls.NAME_KEY: 'Cat 3', cls.API_URL_KEY: 'chatbot-api:cat_3'},
+            {
+                cls.NAME_KEY: cls.LANG_CHAIN,
+                cls.IS_EXPANDED_KEY: True,
+                cls.SUB_ITEMS_KEY: [
+                    {cls.NAME_KEY: 'Prompt Template', cls.API_URL_NAME_KEY: 'chatbot-api:prompt_template'},
+                ],
+            },
         ]
 
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,8 +10,13 @@ python-dotenv==1.1.1
 djangorestframework==3.16.0
 django-filter==25.1
 
-# OpenAI
+# OpenAI & LLM Related
 openai==1.93.3
+google-genai==1.25.0 # new
+# google-generativeai==0.7.2 # Deprecated, but langchain-community still uses it.
+langchain==0.3.26
+langchain-community==0.3.27
+langchain-google-genai==2.1.7 # LangChain compatible google lib
 
 # Debug
 django-debug-toolbar==5.2.0


### PR DESCRIPTION
--Added new required dependencies.
-- init integration of Google LLM's <> LangChain.
--Implemented LangChain `ChatPromptTemplate` - a way to reuse prompt templates.
TODO: extend on top of this.