### PR TITLE
feat: adapt PromptBasedAPIView for LangChain.

### DIFF
--- a/django_gen_ai_examples/apps/chat_bot/api/prompts/langchain_prompt_template_translate.txt
+++ b/django_gen_ai_examples/apps/chat_bot/api/prompts/langchain_prompt_template_translate.txt
@@ -1,0 +1,16 @@
+Your tasks are the following:
+
+Translate the text that is delimited by triple backticks into language that is {language} and use the tone that is {tone}.
+Format the output as HTML, start and end with an div tag. do not include anything else outside of the start and end div tags. Use the following html delimited by triple percentage as guideline on what is expected how it should be formatted:
+%%%<div>
+    <p><strong><!-- insert translated language heading here --> (Translation):</strong></p>
+    <p style="font-size: 1.2em; color: #4CAF50;"><!-- Insert translated text here --></p>
+    <p><strong><!-- insert translated language heading here --> (Additional Information):</strong></p>
+    <ul>
+        <li><strong><!-- insert translated language heading here --> (Original Text):</strong> come here, sit down</li>
+        <li><strong><!-- insert translated language heading here --> (Translated Language):</strong> <!--Insert language here--> (<!-- Insert language in english here -->)</li>
+        <li><strong><!-- insert translated language heading here -->(Tone):</strong> <!--Insert tone in translated language here--> (<!--Insert tone in english here-->)</li>
+    </ul>
+</div>%%%
+
+Text: ```{text}```

--- a/django_gen_ai_examples/apps/chat_bot/api/urls.py
+++ b/django_gen_ai_examples/apps/chat_bot/api/urls.py
@@ -12,5 +12,5 @@ urlpatterns = [
     path('single-prompt/', views.SinglePromptAPIView.as_view(), name='single_prompt'),
     path('summarize/', views.SummarizeTextAPIView.as_view(), name='summarize_text'),
     path('sentiment/', views.SentimentAnalysisAPIView.as_view(), name='sentiment_analysis'),
-    path('lc-prompt-template/', views.LCPromptTemplateAPIView.as_view(), name="prompt_template"),
+    path('translate/', views.LCTranslateAPIView.as_view(), name='translate'),
 ]

--- a/django_gen_ai_examples/apps/chat_bot/api/views.py
+++ b/django_gen_ai_examples/apps/chat_bot/api/views.py
@@ -6,6 +6,7 @@ from typing import Dict, Optional
 
 from django.shortcuts import get_object_or_404
 from django.template import Context, Template
+from django.utils.html import strip_tags
 from langchain.prompts import ChatPromptTemplate
 
 # from langchain.chat_models import ChatGooglePalm # Deprecated.
@@ -48,18 +49,19 @@ class PromptBasedAPIView(APIView):
             response_data.update(message_data)
         return Response(response_data, status=status_code)
 
-    def prompt_render_engine(self, prompt_template, context):
+    def prompt_render_engine(self, context):
         "By default use Django Template to render prompt"
-        template = Template(prompt_template)
+        template = Template(self._get_prompt_tempate_str())
+
         return template.render(Context(context))
 
-    def _get_rendered_prompt(self, context):
-        "Loads and renders the specified prompt template."
+    def _get_prompt_tempate_str(self) -> str:
         if not self.prompt_lookup_key:
             raise NotImplementedError("Subclasses must define 'prompt_lookup_key.'")
 
         prompt_obj = get_object_or_404(PromptTemplate, lookup_key=self.prompt_lookup_key)
-        return self.prompt_render_engine(prompt_obj.prompt_template, context)
+        # NOTE: convert Rich formated [with html tags.] Prompts from TinyMCE into simple text.
+        return strip_tags(prompt_obj.prompt_template or "")
 
     def make_llm_request(self, prompt: str) -> str:
         """
@@ -79,7 +81,7 @@ class PromptBasedAPIView(APIView):
             return Response({"error": "Missing message"}, status=status.HTTP_400_BAD_REQUEST)
 
         try:
-            prompt = self._get_rendered_prompt(context={"request_message": request_message})
+            prompt = self.prompt_render_engine(context={"request_message": request_message})
             api_response = self.make_llm_request(prompt=prompt)
         except FileNotFoundError as e:
             return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
@@ -113,41 +115,35 @@ class SentimentAnalysisAPIView(PromptBasedAPIView):
     prompt_lookup_key = "sentiment-prompt"
 
 
-class LCPromptTemplateAPIView(APIView):
-    "LangChain simple prompt template using the modern ChatGoogleGenerativeAI."
+class LCTranslateAPIView(PromptBasedAPIView):
+    """
+    LangChain: translate using prompt template [ChatPromptTemplate].
+    """
 
-    def post(self, request, *_, **__):
-        "Pass prompt through LangChain PromptTemplate"
-        request_message = request.data.get("message")
-        if not request_message:
-            return Response({"error": "Missing message"}, status=status.HTTP_400_BAD_REQUEST)
+    prompt_lookup_key = "langchain-prompt-template-translate"
+
+    def prompt_render_engine(self, context: dict):
+        "Overridden to use ChatPromptTemplate Engine."
+        prompt_template = ChatPromptTemplate.from_template(
+            self._get_prompt_tempate_str(),
+        )
+
+        # TODO: make language and tone dynamic.
+        language = "Tamil"
+        tone = "Sweet"
+        return prompt_template.format_messages(
+            language=language,
+            tone=tone,
+            text=context.get("request_message"),
+        )
+
+    def make_llm_request(self, prompt: str):
+        "Overridden to use LangChain"
 
         chat = ChatGoogleGenerativeAI(
-            temperature=0.0,
+            temperature=0.3,
             model=GeminiAPIConstants.MODEL,
             google_api_key=get_gemini_api_key(),
         )
 
-        template_string = """Translate the text \
-that is delimited by triple backticks \
-into a style that is {style}. \
-text: ```{text}```
-"""
-
-        style_instruction = """Indian Tamil \
-in a calm and respectful tone
-"""
-
-        prompt_template = ChatPromptTemplate.from_template(template_string)
-
-        formatted_prompt = prompt_template.format_messages(
-            style=style_instruction,
-            text=request_message,
-        )
-
-        api_response = chat.invoke(formatted_prompt)
-
-        response_content = api_response.content
-
-        response_data = {"message": response_content}
-        return Response(response_data, status=status.HTTP_200_OK)
+        return chat.invoke(prompt).content

--- a/django_gen_ai_examples/apps/chat_bot/const.py
+++ b/django_gen_ai_examples/apps/chat_bot/const.py
@@ -40,7 +40,7 @@ class SidebarMenuChoices:
                 cls.NAME_KEY: cls.LANG_CHAIN,
                 cls.IS_EXPANDED_KEY: True,
                 cls.SUB_ITEMS_KEY: [
-                    {cls.NAME_KEY: 'Prompt Template', cls.API_URL_NAME_KEY: 'chatbot-api:prompt_template'},
+                    {cls.NAME_KEY: 'Translate', cls.API_URL_NAME_KEY: 'chatbot-api:translate'},
                 ],
             },
         ]


### PR DESCRIPTION
--Made base `PromptBasedAPIView` more versatile, now it supports both `Django template engine` and LangChain `ChatPromptTemplate`.
--Converting rich formatted prompts back to simple strings using Django's `strip_tags`.