### PR TITLE
Chore: fix calendar summary

### DIFF
--- a/airflow/dags/test_calendar_rag.py
+++ b/airflow/dags/test_calendar_rag.py
@@ -121,7 +121,7 @@ def task_test_user_calendar_summary(**airflow_context):
 
     # Test the summary method
     summary = calendar_rag_service.get_user_calendar_summary(
-        user_email=params["user_email"], days_ahead=params.get("summary_days_ahead", 7)
+        user_email=params["user_email"], days_ahead=params.get("summary_days_ahead", 0)
     )
 
     logger.info("=== USER CALENDAR SUMMARY ===")
@@ -188,9 +188,9 @@ with DAG(
             ),
             "summary_days_ahead": Param(
                 type="integer",
-                minimum=1,
+                minimum=0,
                 maximum=30,
-                default=7,
+                default=0,
                 description="Days ahead for calendar summary",
             ),
         }

--- a/django_gen_ai_examples/apps/chat_bot/services/rag_service.py
+++ b/django_gen_ai_examples/apps/chat_bot/services/rag_service.py
@@ -28,8 +28,8 @@ class CalendarRAGService:
     """
 
     def __init__(self):
-        self.default_similarity_threshold = 0.35
-        self.max_results = 10
+        self.default_similarity_threshold = 0.5
+        self.max_results = 50
 
     def query_calendar_events(
         self,
@@ -259,9 +259,12 @@ class CalendarRAGService:
         start_date = timezone.now()
         end_date = start_date + timedelta(days=days_ahead)
 
-        events = CalendarEvent.objects.filter(
-            user=user, start_datetime__gte=start_date, start_datetime__lte=end_date
-        ).order_by("start_datetime")
+        if days_ahead == 0:
+            q_filter = Q(user=user, start_datetime__date=start_date.date())
+        else:
+            q_filter = Q(user=user, start_datetime__gte=start_date, start_datetime__lte=end_date)
+
+        events = CalendarEvent.objects.filter(q_filter).order_by("start_datetime")
 
         summary: Dict[str, Any] = {
             "user_email": user_email,


### PR DESCRIPTION
--when days_ahead was 0 it made it impossible to get just todays calendar summary. this is now fixed.